### PR TITLE
Removing Django Compress

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ wheel==0.24.0
 python-dateutil
 django_compressor
 django-angular
+django-storages

--- a/root/settings.py
+++ b/root/settings.py
@@ -144,8 +144,7 @@ STATICFILES_FINDERS = [
 API_URL = os.environ.get('API_URL', 'http://api.refugee.info')
 BLUE_PAGES = os.environ.get('BLUE_PAGES', 'serbia').split(';')
 
-
-if 'MEMCACHED_URL' in os.environ:
+`if 'MEMCACHED_URL' in os.environ:
     from urllib.parse import urlparse
 
     memcached = urlparse(os.environ.get('MEMCACHED_URL'))
@@ -166,12 +165,32 @@ else:
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
-COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = True
+COMPRESS_ENABLED = False
+COMPRESS_OFFLINE = False
 
 COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'sass --scss {infile} {outfile}'),
 )
+
+if 'AWS_ACCESS_KEY_ID' in os.environ:
+    AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
+    AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
+    AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', 'new-refugee-info')
+
+    CLOUDFRONT_URL = os.environ.get('CLOUDFRONT_URL', 'https://new-refugee-info.s3.amazonaws.com/')
+
+    # Static files location
+    STATICFILES_STORAGE = 'root.storages.StaticFilesStorage'
+
+    # Default File storage
+    MEDIAFILES_LOCATION = 'media'
+    STATICFILES_LOCATION = 'static'
+
+    MEDIA_URL = "%s%s/" % (CLOUDFRONT_URL, MEDIAFILES_LOCATION,)
+    COMPRESS_URL = STATIC_URL = CLOUDFRONT_URL
+    COMPRESS_STORAGE = 'root.storages.S3BotoStorage'
+
+
 
 try:
     from .localsettings import *

--- a/root/settings.py
+++ b/root/settings.py
@@ -144,7 +144,7 @@ STATICFILES_FINDERS = [
 API_URL = os.environ.get('API_URL', 'http://api.refugee.info')
 BLUE_PAGES = os.environ.get('BLUE_PAGES', 'serbia').split(';')
 
-`if 'MEMCACHED_URL' in os.environ:
+if 'MEMCACHED_URL' in os.environ:
     from urllib.parse import urlparse
 
     memcached = urlparse(os.environ.get('MEMCACHED_URL'))

--- a/root/storages.py
+++ b/root/storages.py
@@ -1,0 +1,44 @@
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.core.files.storage import get_storage_class
+from storages.backends.s3boto import S3BotoStorage
+from storages.backends.s3boto import S3BotoStorage
+
+__author__ = 'reyrodrigues'
+
+
+class CachedS3BotoStorage(S3BotoStorage):
+    """
+    S3 storage backend that saves the files locally, too.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(CachedS3BotoStorage, self).__init__(*args, **kwargs)
+        self.local_storage = get_storage_class(
+            "compressor.storage.CompressorFileStorage")()
+
+    def save(self, name, content):
+        self.local_storage._save(name, content)
+        super().save(name, self.local_storage._open(name))
+        return name
+
+
+def domain(url):
+    return urlparse(url).hostname
+
+
+class MediaFilesStorage(S3BotoStorage):
+    location = settings.MEDIAFILES_LOCATION
+
+    def __init__(self, *args, **kwargs):
+        kwargs['bucket'] = settings.AWS_STORAGE_BUCKET_NAME
+        kwargs['custom_domain'] = domain(settings.MEDIA_URL)
+        super().__init__(*args, **kwargs)
+
+
+class StaticFilesStorage(S3BotoStorage):
+    def __init__(self, *args, **kwargs):
+        kwargs['bucket'] = settings.AWS_STORAGE_BUCKET_NAME
+        kwargs['custom_domain'] = domain(settings.STATIC_URL)
+        super().__init__(*args, **kwargs)

--- a/simple_ui/templates/base.html
+++ b/simple_ui/templates/base.html
@@ -1,5 +1,4 @@
 {% load static %}
-{% load compress %}
 {% load djng_tags %}
 {% load marktags %}
 {% cookie 'theme' as theme %}
@@ -49,7 +48,6 @@
     <script type="text/javascript" src='{% static 'angular-snap/angular-snap.min.js' %}'></script>
     <script type="text/javascript" src='{% static 'Leaflet.label/dist/leaflet.label.js' %}'></script>
 
-    {% compress js %}
         <script type="text/javascript" src='{% static 'js/refugeeApp/app.js' %}'></script>
 
         <script type="text/javascript" src='{% static 'js/refugeeApp/services/LocationService.js' %}'></script>
@@ -80,7 +78,6 @@
         <script type="text/javascript" src='{% static 'js/refugeeApp/directives/quickLinks.js' %}'></script>
         <script type="text/javascript" src='{% static 'js/refugeeApp/directives/changeLocationButton.js' %}'></script>
 
-    {% endcompress %}
 
     <script type="text/javascript">
         angular.module('refugeeApp').constant('apiUrl', '{{ API_URL }}');
@@ -99,9 +96,7 @@
 
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet">
 
-    {% compress css %}
-    <link rel="stylesheet" type="text/x-scss" href="{% static 'scss/main.scss' %}">
-    {% endcompress %}
+    <link rel="stylesheet" href="{% static 'scss/main.css' %}">
 
 
     {% block additional-requirements %}{% endblock %}

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
 bower install; \
-python manage.py compress; \
+sass simple_ui/static/scss/main.scss > simple_ui/static/scss/main.css; \
 python manage.py collectstatic --noinput; \
 gunicorn root.wsgi --log-file -


### PR DESCRIPTION
Compress doesn't play well with having multiple servers on the backend. Removed it for now while we can study in the future how to use it with S3 and CloudFront.