### PR TITLE
Opening hours text styling

### DIFF
--- a/simple_ui/templates/angular/partials/directives/service-details.html
+++ b/simple_ui/templates/angular/partials/directives/service-details.html
@@ -46,7 +46,7 @@
             <i class="fa fa-2x fa-clock-o" style="margin: 20px 15px 15px 15px"></i>
             <div class="opening-hours-table">
                 <h2 class="service-description-title">{$ 'OPENING_HOURS' | translate $}</h2>
-                <p ng-if="ctrl.opening_time['24/7']">
+                <p class="service-description-body" ng-if="ctrl.opening_time['24/7']">
                     {$ 'OPEN_24_7' | translate $}
                 </p>
                 <table ng-if="!ctrl.opening_time['24/7']" class="service-opening-hours-table" style="width: 100%">


### PR DESCRIPTION
https://trello.com/c/6LnuZyko/71-tweak-to-the-opening-hours-field-when-the-24-7-option-is-selected-could-the-message-the-service-is-open-24-7-match-the-size-colo